### PR TITLE
Avoid loud promotion and war sound

### DIFF
--- a/CvGameCoreDLL/CvDeal.cpp
+++ b/CvGameCoreDLL/CvDeal.cpp
@@ -63,8 +63,8 @@ void CvDeal::reset(int iID, PlayerTypes eFirstPlayer, PlayerTypes eSecondPlayer)
 	m_eSecondPlayer = eSecondPlayer;
 }
 
-
-void CvDeal::kill(bool bKillTeam)
+// trs.sound-once
+void CvDeal::kill(bool bKillTeam, bool bPlaySound)
 {
 	if ((getLengthFirstTrades() > 0) || (getLengthSecondTrades() > 0))
 	{
@@ -77,7 +77,9 @@ void CvDeal::kill(bool bKillTeam)
 			szDealString.clear();
 			GAMETEXT.getDealString(szDealString, *this, getFirstPlayer());
 			szString.Format(L"%s: %s", szCancelString.GetCString(), szDealString.getCString());
-			gDLL->getInterfaceIFace()->addHumanMessage((PlayerTypes)getFirstPlayer(), true, GC.getEVENT_MESSAGE_TIME(), szString, "AS2D_DEAL_CANCELLED");
+			gDLL->getInterfaceIFace()->addHumanMessage((PlayerTypes)getFirstPlayer(), true, GC.getEVENT_MESSAGE_TIME(), szString,
+					bPlaySound ? "AS2D_DEAL_CANCELLED" : NULL // trs.sound-once
+					);
 		}
 
 		if (GET_TEAM(GET_PLAYER(getSecondPlayer()).getTeam()).isHasMet(GET_PLAYER(getFirstPlayer()).getTeam()))
@@ -85,7 +87,9 @@ void CvDeal::kill(bool bKillTeam)
 			szDealString.clear();
 			GAMETEXT.getDealString(szDealString, *this, getSecondPlayer());
 			szString.Format(L"%s: %s", szCancelString.GetCString(), szDealString.getCString());
-			gDLL->getInterfaceIFace()->addHumanMessage((PlayerTypes)getSecondPlayer(), true, GC.getEVENT_MESSAGE_TIME(), szString, "AS2D_DEAL_CANCELLED");
+			gDLL->getInterfaceIFace()->addHumanMessage((PlayerTypes)getSecondPlayer(), true, GC.getEVENT_MESSAGE_TIME(), szString,
+				bPlaySound ? "AS2D_DEAL_CANCELLED" : NULL // trs.sound-once
+				);
 		}
 	}
 
@@ -354,8 +358,8 @@ void CvDeal::verify()
 		{
 			// XXX embargoes?
 			if ((kFirstPlayer.getNumTradeableBonuses((BonusTypes)(pNode->m_data.m_iData)) < 0) ||
-				  !(kFirstPlayer.canTradeNetworkWith(getSecondPlayer())) || 
-				  GET_TEAM(kFirstPlayer.getTeam()).isBonusObsolete((BonusTypes) pNode->m_data.m_iData) || 
+				  !(kFirstPlayer.canTradeNetworkWith(getSecondPlayer())) ||
+				  GET_TEAM(kFirstPlayer.getTeam()).isBonusObsolete((BonusTypes) pNode->m_data.m_iData) ||
 				  GET_TEAM(kSecondPlayer.getTeam()).isBonusObsolete((BonusTypes) pNode->m_data.m_iData))
 			{
 				bCancelDeal = true;
@@ -369,8 +373,8 @@ void CvDeal::verify()
 		{
 			// XXX embargoes?
 			if ((GET_PLAYER(getSecondPlayer()).getNumTradeableBonuses((BonusTypes)(pNode->m_data.m_iData)) < 0) ||
-				  !(GET_PLAYER(getSecondPlayer()).canTradeNetworkWith(getFirstPlayer())) || 
-				  GET_TEAM(kFirstPlayer.getTeam()).isBonusObsolete((BonusTypes) pNode->m_data.m_iData) || 
+				  !(GET_PLAYER(getSecondPlayer()).canTradeNetworkWith(getFirstPlayer())) ||
+				  GET_TEAM(kFirstPlayer.getTeam()).isBonusObsolete((BonusTypes) pNode->m_data.m_iData) ||
 				  GET_TEAM(kSecondPlayer.getTeam()).isBonusObsolete((BonusTypes) pNode->m_data.m_iData))
 			{
 				bCancelDeal = true;
@@ -462,7 +466,7 @@ bool CvDeal::isUncancelableVassalDeal(PlayerTypes eByPlayer, CvWString* pszReaso
 		{
 			CvTeam& kVassal = GET_TEAM(GET_PLAYER(getFirstPlayer()).getTeam());
 			TeamTypes eMaster = GET_PLAYER(getSecondPlayer()).getTeam();
-			
+
 			if (!kVassal.canVassalRevolt(eMaster))
 			{
 				if (pszReason)
@@ -496,7 +500,7 @@ bool CvDeal::isUncancelableVassalDeal(PlayerTypes eByPlayer, CvWString* pszReaso
 		{
 			CvTeam& kVassal = GET_TEAM(GET_PLAYER(getSecondPlayer()).getTeam());
 			TeamTypes eMaster = GET_PLAYER(getFirstPlayer()).getTeam();
-			
+
 			if (!kVassal.canVassalRevolt(eMaster))
 			{
 				if (pszReason)
@@ -777,16 +781,16 @@ bool CvDeal::startTrade(TradeData trade, PlayerTypes eFromPlayer, PlayerTypes eT
 			}
 		}
 
-		for (iI = 0; iI < MAX_PLAYERS; iI++) 
-		{ 
-			if (GET_PLAYER((PlayerTypes)iI).isAlive()) 
-			{ 
-				if (GET_PLAYER((PlayerTypes)iI).getTeam() == GET_PLAYER(eToPlayer).getTeam()) 
-				{ 
-					GET_PLAYER((PlayerTypes)iI).updatePlotGroups(); 
-				} 
-			} 
-		} 
+		for (iI = 0; iI < MAX_PLAYERS; iI++)
+		{
+			if (GET_PLAYER((PlayerTypes)iI).isAlive())
+			{
+				if (GET_PLAYER((PlayerTypes)iI).getTeam() == GET_PLAYER(eToPlayer).getTeam())
+				{
+					GET_PLAYER((PlayerTypes)iI).updatePlotGroups();
+				}
+			}
+		}
 		break;
 
 	case TRADE_SURRENDER:
@@ -1129,7 +1133,7 @@ bool CvDeal::isAnnual(TradeableItems eItem)
 		return true;
 		break;
 	}
-	
+
 	return false;
 }
 
@@ -1200,5 +1204,3 @@ TradeableItems CvDeal::getGoldPerTurnItem()
 {
 	return TRADE_GOLD_PER_TURN;
 }
-
-

--- a/CvGameCoreDLL/CvDeal.h
+++ b/CvGameCoreDLL/CvDeal.h
@@ -20,7 +20,13 @@ public:
 	void uninit();
 	void reset(int iID = 0, PlayerTypes eFirstPlayer = NO_PLAYER, PlayerTypes eSecondPlayer = NO_PLAYER);
 
-	DllExport void kill(bool bKillTeam = true);
+	DllExport void kill(bool bKillTeam = true)
+	// <trs.sound-once>
+	{
+		kill(bKillTeam, true);
+	}
+	void kill(bool bKillTeam, bool bPlaySound);
+	// </trs.sound-once>
 
 	void addTrades(CLinkList<TradeData>* pFirstList, CLinkList<TradeData>* pSecondList, bool bCheckAllowed);
 

--- a/CvGameCoreDLL/CvGame.cpp
+++ b/CvGameCoreDLL/CvGame.cpp
@@ -6120,6 +6120,7 @@ void CvGame::doGlobalWarming()
 
 	TerrainTypes eWarmingTerrain = ((TerrainTypes)(GC.getDefineINT("GLOBAL_WARMING_TERRAIN")));
 
+	bool bSoundPlayed = false; // trs.sound-once
 	for (int iI = 0; iI < iGlobalWarmingValue; iI++)
 	{
 		if (getSorenRandNum(100, "Global Warming") + iGlobalWarmingDefense < GC.getDefineINT("GLOBAL_WARMING_PROB"))
@@ -6157,7 +6158,8 @@ void CvGame::doGlobalWarming()
 						if (pPlot->isVisible(pCity->getTeam(), false))
 						{
 							CvWString szBuffer = gDLL->getText("TXT_KEY_MISC_GLOBAL_WARMING_NEAR_CITY", pCity->getNameKey());
-							gDLL->getInterfaceIFace()->addHumanMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_GLOBALWARMING", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+							// trs.sound-once
+							gDLL->getInterfaceIFace()->addHumanMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, bSoundPlayed ? NULL : "AS2D_GLOBALWARMING", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
 						}
 					}
 				}
@@ -9928,7 +9930,7 @@ bool CvGame::safeMotherland( int iCiv ){
 			return true;
 		};
 	};
-	
+
 	// Absinthe: Check if there are more own cities than foreign cities in the normal area - base rectangle.
 	int iCitiesOwned=0, iCitiesLost=0;
 	for ( x=NormalAreasRect[iCiv][0]; x<=NormalAreasRect[iCiv][2]; x++ ){

--- a/CvGameCoreDLL/CvTeam.cpp
+++ b/CvGameCoreDLL/CvTeam.cpp
@@ -1195,6 +1195,7 @@ void CvTeam::declareWar(TeamTypes eTeam, bool bNewDiplo, WarPlanTypes eWarPlan)
 	FAssertMsg(eTeam != getID(), "eTeam is not expected to be equal with getID()");
 
 	if (eTeam == getID()) return; //Rhye
+	bool bDealSoundPlayed = false; // trs.sound-once
 
 	if (!isAtWar(eTeam))
 	{
@@ -1205,7 +1206,10 @@ void CvTeam::declareWar(TeamTypes eTeam, bool bNewDiplo, WarPlanTypes eWarPlan)
 			if (((GET_PLAYER(pLoopDeal->getFirstPlayer()).getTeam() == getID()) && (GET_PLAYER(pLoopDeal->getSecondPlayer()).getTeam() == eTeam)) ||
 					((GET_PLAYER(pLoopDeal->getFirstPlayer()).getTeam() == eTeam) && (GET_PLAYER(pLoopDeal->getSecondPlayer()).getTeam() == getID())))
 			{
-				pLoopDeal->kill();
+				// <trs.sound-once>
+				pLoopDeal->kill(true, !bDealSoundPlayed);
+				bDealSoundPlayed = true;
+				// </trs.sound-once>
 			}
 		}
 
@@ -1496,6 +1500,10 @@ void CvTeam::declareWar(TeamTypes eTeam, bool bNewDiplo, WarPlanTypes eWarPlan)
 				}
 			}
 
+			// <trs.sound-once>
+			bool const bPlaySound = ((!isAVassal() || isHuman()) && !GET_TEAM(eTeam).isAVassal() || GET_TEAM(eTeam).isHuman());
+			// </trs.sound-once>
+
 			if (!isBarbarian() && !(GET_TEAM(eTeam).isBarbarian()) &&
 				  !isMinorCiv() && !(GET_TEAM(eTeam).isMinorCiv()))
 			{
@@ -1507,19 +1515,19 @@ void CvTeam::declareWar(TeamTypes eTeam, bool bNewDiplo, WarPlanTypes eWarPlan)
 						{
 							//szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_DECLARED_WAR_ON", GET_TEAM(eTeam).getName().GetCString()); //Rhye
 							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_DECLARED_WAR_ON", GET_PLAYER((PlayerTypes)eTeam).getCivilizationShortDescription()); //Rhye
-							gDLL->getInterfaceIFace()->addHumanMessage(((PlayerTypes)iI), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_DECLAREWAR", MESSAGE_TYPE_MAJOR_EVENT, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_WARNING_TEXT"));
+							gDLL->getInterfaceIFace()->addHumanMessage(((PlayerTypes)iI), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, bPlaySound ? "AS2D_DECLAREWAR" : NULL, MESSAGE_TYPE_MAJOR_EVENT, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_WARNING_TEXT"));
 						}
 						else if (GET_PLAYER((PlayerTypes)iI).getTeam() == eTeam)
 						{
 							//szBuffer = gDLL->getText("TXT_KEY_MISC_DECLARED_WAR_ON_YOU", getName().GetCString()); //Rhye
 							szBuffer = gDLL->getText("TXT_KEY_MISC_DECLARED_WAR_ON_YOU", GET_PLAYER((PlayerTypes)getID()).getCivilizationShortDescription()); //Rhye
-							gDLL->getInterfaceIFace()->addHumanMessage(((PlayerTypes)iI), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_DECLAREWAR", MESSAGE_TYPE_MAJOR_EVENT, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_WARNING_TEXT"));
+							gDLL->getInterfaceIFace()->addHumanMessage(((PlayerTypes)iI), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, bPlaySound ? "AS2D_DECLAREWAR" : NULL, MESSAGE_TYPE_MAJOR_EVENT, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_WARNING_TEXT"));
 						}
 						else if (GET_TEAM(GET_PLAYER((PlayerTypes)iI).getTeam()).isHasMet(getID()) && GET_TEAM(GET_PLAYER((PlayerTypes)iI).getTeam()).isHasMet(eTeam))
 						{
 							//szBuffer = gDLL->getText("TXT_KEY_MISC_SOMEONE_DECLARED_WAR", getName().GetCString(), GET_TEAM(eTeam).getName().GetCString()); //Rhye
 							szBuffer = gDLL->getText("TXT_KEY_MISC_SOMEONE_DECLARED_WAR", GET_PLAYER((PlayerTypes)getID()).getCivilizationShortDescription(), GET_PLAYER((PlayerTypes)eTeam).getCivilizationShortDescription()); //Rhye
-							gDLL->getInterfaceIFace()->addHumanMessage(((PlayerTypes)iI), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_THEIRDECLAREWAR", MESSAGE_TYPE_MAJOR_EVENT, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_WARNING_TEXT"));
+							gDLL->getInterfaceIFace()->addHumanMessage(((PlayerTypes)iI), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, bPlaySound ? "AS2D_DECLAREWAR" : NULL, MESSAGE_TYPE_MAJOR_EVENT, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_WARNING_TEXT"));
 						}
 					}
 				}
@@ -1601,7 +1609,9 @@ void CvTeam::declareWar(TeamTypes eTeam, bool bNewDiplo, WarPlanTypes eWarPlan)
 
 							if (bCancelDeal)
 							{
-								pLoopDeal->kill();
+								// <trs.sound-once>
+								pLoopDeal->kill(true, !bDealSoundPlayed); bDealSoundPlayed = true;
+								// </trs.sound-once>
 							}
 						}
 					}

--- a/CvGameCoreDLL/CvUnit.cpp
+++ b/CvGameCoreDLL/CvUnit.cpp
@@ -6656,7 +6656,7 @@ bool CvUnit::canPromote(PromotionTypes ePromotion, int iLeaderUnitId) const
 			return false;
 		}
 		// Absinthe: end
-		
+
 		if (iLeaderUnitId >= 0)
 		{
 			CvUnit* pWarlord = GET_PLAYER(getOwnerINLINE()).getUnit(iLeaderUnitId);
@@ -6685,6 +6685,7 @@ void CvUnit::promote(PromotionTypes ePromotion, int iLeaderUnitId)
 		return;
 	}
 
+	bool bPlaySound = true; // trs.sound-once
 	if (iLeaderUnitId >= 0)
 	{
 		CvUnit* pWarlord = GET_PLAYER(getOwnerINLINE()).getUnit(iLeaderUnitId);
@@ -6701,6 +6702,26 @@ void CvUnit::promote(PromotionTypes ePromotion, int iLeaderUnitId)
 			reloadEntity();
 		}
 	}
+	// <trs.sound-once> (from AdvCiv)
+	else if (IsSelected())
+	{
+		int iSelectedCanPromote = 0;
+		for (CLLNode<IDInfo>* pNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+			pNode != NULL; pNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pNode))
+		{
+			CvUnit const* pUnit = ::getUnit(pNode->m_data);
+			if (pUnit != NULL && pUnit->canPromote(ePromotion, iLeaderUnitId))
+			{
+				iSelectedCanPromote++;
+				// Play sound only for the last promoted unit in a selected stack
+				if (iSelectedCanPromote > 1)
+				{
+					bPlaySound = false;
+					break;
+				}
+			}
+		}
+	} // </trs.sound-once>
 
 	if (!GC.getPromotionInfo(ePromotion).isLeader())
 	{
@@ -6714,7 +6735,8 @@ void CvUnit::promote(PromotionTypes ePromotion, int iLeaderUnitId)
 
 	if (IsSelected())
 	{
-		gDLL->getInterfaceIFace()->playGeneralSound(GC.getPromotionInfo(ePromotion).getSound());
+		if (bPlaySound) // trs.sound-once
+			gDLL->getInterfaceIFace()->playGeneralSound(GC.getPromotionInfo(ePromotion).getSound());
 
 		gDLL->getInterfaceIFace()->setDirty(UnitInfo_DIRTY_BIT, true);
 	}


### PR DESCRIPTION
This pull request is a cherry picking of this [commit](https://github.com/f1rpo/Taurus/commit/822aa7161bbf497ea4db712ec7367e125af913f1) from the [Taurus mod](https://github.com/f1rpo/Taurus).
It avoids playing the same sound when a stack of units is promoted or a war is declared to several players.