### PR TITLE
Improve income warning color

### DIFF
--- a/Assets/Python/screens/CvMainInterface.py
+++ b/Assets/Python/screens/CvMainInterface.py
@@ -5298,6 +5298,12 @@ class CvMainInterface:
                     # Get the new modified gold string
                     iGoldRate = calculate_gold_rate(ePlayer)
                     # # < Mercenaries End   >
+                    iCurrentResearch = pPlayer.getCurrentResearch()
+                    iResearchTurnsLeft = (
+                        iCurrentResearch >= 0
+                        and pPlayer.getResearchTurnsLeft(iCurrentResearch, True)
+                        or None
+                    )
                     if iGold < 0:
                         szText = BugUtil.getText("TXT_KEY_MISC_NEG_GOLD", iGold)
                         if iGoldRate != 0:
@@ -5320,9 +5326,16 @@ class CvMainInterface:
                                 szText += BugUtil.getText(
                                     "TXT_KEY_MISC_POS_GOLD_PER_TURN", iGoldRate
                                 )
-                            elif iGold + iGoldRate >= 0:
+                            elif (
+                                iCurrentResearch >= 0
+                                and iGold + iGoldRate * iResearchTurnsLeft >= 0
+                            ):
                                 szText += BugUtil.getText(
                                     "TXT_KEY_MISC_NEG_WARNING_GOLD_PER_TURN", iGoldRate
+                                )
+                            elif iGold + iGoldRate >= 0:
+                                szText += BugUtil.getText(
+                                    "TXT_KEY_MISC_NEG_STRONG_WARNING_GOLD_PER_TURN", iGoldRate
                                 )
                             else:
                                 szText += BugUtil.getText(

--- a/Assets/XML/Text/External/BUG_CIV4GameText.xml
+++ b/Assets/XML/Text/External/BUG_CIV4GameText.xml
@@ -155,6 +155,14 @@
 		<Spanish>[SPACE][COLOR_YELLOW](%D1_Change/turno)[COLOR_REVERT]</Spanish>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_MISC_NEG_STRONG_WARNING_GOLD_PER_TURN</Tag>
+		<English>[SPACE][COLOR_PLAYER_ORANGE_TEXT](%D1_Change/Turn)[COLOR_REVERT]</English>
+		<French>[SPACE][COLOR_ORANGE](%D1_Change/tour)[COLOR_REVERT]</French>
+		<German>[SPACE][COLOR_ORANGE](%D1_Change/Runde)[COLOR_REVERT]</German>
+		<Italian>[SPACE][COLOR_ORANGE](%D1_Change/Turno)[COLOR_REVERT]</Italian>
+		<Spanish>[SPACE][COLOR_ORANGE](%D1_Change/turno)[COLOR_REVERT]</Spanish>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_MISC_POS_WARNING_GOLD_PER_TURN</Tag>
 		<English>[SPACE][COLOR_YELLOW](%D1_Change/Turn)[COLOR_REVERT]</English>
 		<French>[SPACE][COLOR_YELLOW](%D1_Change/tour)[COLOR_REVERT]</French>


### PR DESCRIPTION
# What does this PR do?

This PR improves the income warning colour to signify if current research is fully funded.
Taken from https://github.com/dguenms/Dawn-of-Civilization/commit/0881c38800fe49d40e16aced8b8ec1f2a78b3ead

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?
